### PR TITLE
fix(apache): add quotes to DocumentRoot path

### DIFF
--- a/tasks/apache.yml
+++ b/tasks/apache.yml
@@ -9,7 +9,7 @@
   lineinfile:
     path: "{{ item }}"
     regexp: '^(\s+)DocumentRoot\s+.*'
-    line: '\1DocumentRoot {{ ezeelogin_web_panel_files_path }}'
+    line: '\1DocumentRoot "{{ ezeelogin_web_panel_files_path }}"'
     backrefs: True
   loop: "{{ apache_enabled_sites.files | map(attribute='path') }}"
   notify: restart apache


### PR DESCRIPTION
As per the Apache documentation.